### PR TITLE
chore(ci): support npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,60 +1,122 @@
 name: Release
 
+# Triggers:
+#   - tag push (v*): publish to npm, then update the release notes.
+#   - workflow_dispatch: retry either job for an existing tag.
 on:
   push:
     branches-ignore:
       - '**'
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      job:
+        description: Which job to run
+        type: choice
+        required: true
+        default: all
+        options:
+          - all
+          - npm-publish
+          - release-notes
+      tag:
+        description: Existing tag to release (e.g. v1.2.3)
+        type: string
+        required: true
+
+env:
+  TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+permissions: {}
+
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
-  release:
+  npm-publish:
+    name: Publish to npm
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' &&
+        (inputs.job == 'all' || inputs.job == 'npm-publish'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm OIDC trusted publisher
+
     steps:
       - name: Checkout codes
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ env.TAG }}
+          persist-credentials: false
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 16.x
+          node-version: 24
+          package-manager-cache: false
 
-      - name: Extract version tag
-        if: startsWith( github.ref, 'refs/tags/v' )
-        uses: jungwinter/split@v2
-        id: split
+      - name: Install npm
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish to npm
+        # OIDC trusted publisher: requires id-token: write, no NPM_TOKEN needed.
+        # Provenance is automatically attached via OIDC.
+        run: pnpm publish --access public --no-git-checks --tag latest
+
+  release-notes:
+    name: Update release notes
+    needs:
+      - npm-publish
+    if: >-
+      always() && (
+        (github.event_name == 'push' && needs.npm-publish.result == 'success') ||
+        (github.event_name == 'workflow_dispatch' && inputs.job == 'release-notes') ||
+        (github.event_name == 'workflow_dispatch' && inputs.job == 'all' &&
+          needs.npm-publish.result == 'success')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # GitHub Release creation + CHANGELOG push
+
+    steps:
+      - name: Checkout codes
+        # zizmor: ignore[artipacked] -- git-auto-commit-action needs persisted credentials to push.
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          msg: ${{ github.ref }}
-          separator: '/'
+          ref: main
+          fetch-depth: 0
 
-      - name: Create Github Release
-        run: gh release create ${{ steps.split.outputs._2 }} --generate-notes
+      - name: Create GitHub Release
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping creation"
+          else
+            gh release create "$TAG" --generate-notes
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 7.33.7
-
-      - name: Generate changelog
-        run: |
-          pnpm install --no-frozen-lockfile
-          pnpm build
-          ./cli.mjs --repo=kazupon/gh-changelogen --tag=${{ steps.split.outputs._2 }}
+      - name: Sync changelog from GitHub Releases
+        run: npx gh-changelogen --repo=kazupon/gh-changelogen --tag="$TAG"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit changelog
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           branch: main
-          file_pattern: '*.md'
-          commit_message: 'chore: sync changelog'
-
-      - name: Publish package
-        run: ./scripts/release.sh
-        env:
-          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+          file_pattern: CHANGELOG.md
+          commit_message: 'chore: generate changelog'


### PR DESCRIPTION
## Summary

- publish tagged releases through npm trusted publishing with GitHub Actions OIDC
- isolate `id-token: write` in the npm publish job and remove the stable release's `NPM_TOKEN` dependency
- use Node.js 24 and the latest npm CLI required for trusted publishing
- run release-note generation only after npm publish succeeds
- add an idempotent manual recovery path for existing tags
- pin third-party actions and prevent concurrent releases for the same tag

## Why

The existing release workflow authenticated with a long-lived npm token and used an npm/Node toolchain that did not support npm trusted publishing. This change follows the release workflow used by `args-tokens`, so npm can exchange the GitHub Actions OIDC identity for a short-lived publish credential and attach provenance automatically.

## Validation

- `actionlint .github/workflows/release.yml`
- `zizmor --persona=pedantic --min-severity=medium .github/workflows/release.yml`
- `pnpm exec prettier --config .prettierrc --check .github/workflows/release.yml`
- `pnpm build`
- `pnpm lint`
- `pnpm deadcode`
- `pnpm test` (20 tests)
- `npm pack --dry-run --json --ignore-scripts`

A full publish dry-run reached npm successfully but stopped at the expected duplicate-version check because `gh-changelogen@0.2.8` is already published.

## npm configuration required

Configure the `gh-changelogen` package's Trusted Publisher on npm with:

- Provider: GitHub Actions
- Organization or user: `kazupon`
- Repository: `gh-changelogen`
- Workflow filename: `release.yml`
- Allowed action: `npm publish`
