### PR TITLE
fix(ci): publish directly with npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Publish to npm
         # OIDC trusted publisher: requires id-token: write, no NPM_TOKEN needed.
         # Provenance is automatically attached via OIDC.
-        run: pnpm publish --access public --no-git-checks --tag latest
+        run: npm publish --access public --tag latest
 
   release-notes:
     name: Update release notes


### PR DESCRIPTION
## Summary

- publish with the npm CLI directly instead of routing through pnpm 7
- remove the pnpm-only `--no-git-checks` option from the npm invocation

## Root cause

The v0.2.9 release failed before OIDC authentication because pnpm 7 forwarded `--no-git-checks` to the latest npm CLI as `--git-checks`. The latest npm rejects that unknown option with `EUNKNOWNCONFIG`.

Failed run: https://github.com/kazupon/gh-changelogen/actions/runs/30750849658/job/91504516362

Directly invoking `npm publish` lets the installed npm CLI handle trusted publishing and avoids pnpm's incompatible option forwarding.

## Impact

`gh-changelogen@0.2.9` remains unpublished, and the release-notes job was skipped. After this PR is merged, rerun the Release workflow with:

- job: `all`
- tag: `v0.2.9`

## Validation

- `actionlint .github/workflows/release.yml`
- `zizmor --persona=pedantic --min-severity=medium .github/workflows/release.yml`
- `pnpm exec prettier --config .prettierrc --check .github/workflows/release.yml`
- `npx --yes npm@latest publish --access public --tag latest --dry-run`

The npm dry-run completed prepack and package creation without `EUNKNOWNCONFIG`, then stopped at the expected duplicate-version check for the already-published local version `0.2.8`.
