### PR TITLE
fix(ci): restore release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,21 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
       - name: Create GitHub Release
         run: |
           if gh release view "$TAG" >/dev/null 2>&1; then
@@ -110,7 +125,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sync changelog from GitHub Releases
-        run: npx gh-changelogen --repo=kazupon/gh-changelogen --tag="$TAG"
+        run: ./cli.mjs --repo=kazupon/gh-changelogen --tag="$TAG"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-changelogen",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Changelog generator for GitHub Releases",
   "keywords": [
     "github",


### PR DESCRIPTION
## Summary

- install dependencies and build gh-changelogen inside the release-notes job
- run the built local CLI directly instead of resolving it through `npx`
- synchronize the main branch package version with the published `0.2.9` release

## Root cause

The npm publish job succeeded, but the release-notes job failed because `npx gh-changelogen` resolved the checked-out root package. That checkout had not installed dependencies or built `dist/cli.mjs`, so Node failed with `ERR_MODULE_NOT_FOUND`.

Failed job: https://github.com/kazupon/gh-changelogen/actions/runs/30751172135/job/91505420946

The v0.2.9 version commit was also created on the previous feature branch rather than `main`, leaving `main` at version 0.2.8 after the package had already been published.

## Impact and recovery

`gh-changelogen@0.2.9` and GitHub Release `v0.2.9` are already published. After merging this PR, rerun the Release workflow with:

- job: `release-notes`
- tag: `v0.2.9`

Do not rerun `npm-publish` or `all`, because version 0.2.9 is already on npm.

## Validation

- `actionlint .github/workflows/release.yml`
- `zizmor --persona=pedantic --min-severity=medium .github/workflows/release.yml`
- `pnpm exec prettier --config .prettierrc --check .github/workflows/release.yml package.json`
- `pnpm install --frozen-lockfile`
- `pnpm build`
- imported `dist/cli.mjs` and verified its `main` export
