### PR TITLE
chore(tooling): drop direct TypeScript dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "bumpp": "^12.0.0",
     "knip": "^6.16.1",
     "pkg-pr-new": "^0.0.86",
-    "typescript": "^6.0.0",
     "vite": "catalog:",
     "vite-plus": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       pkg-pr-new:
         specifier: ^0.0.86
         version: 0.0.86
-      typescript:
-        specifier: ^6.0.0
-        version: 6.0.3
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.7
         version: '@voidzero-dev/vite-plus-core@0.2.7(@types/node@18.19.130)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0)'
@@ -3342,7 +3339,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript@6.0.3: {}
+  typescript@6.0.3:
+    optional: true
 
   ufo@0.8.6: {}
 


### PR DESCRIPTION
## Summary

- remove the direct `typescript` development dependency
- update the pnpm lockfile so TypeScript is no longer installed at the project root
- retain Vite+ core's optional TypeScript peer metadata in the lockfile

## Why

`vp check` performs type checking with the bundled `oxlint-tsgolint` toolchain, while `vp pack` uses bundled tsdown for declaration generation. The project does not invoke the TypeScript package directly.

## Impact

Contributor commands remain unchanged. Type checking, tests, Knip, library builds, and declaration generation continue to run through Vite+.

## Validation

- [x] fresh `vp install --frozen-lockfile`
- [x] confirmed no direct `typescript` dependency or root `node_modules/typescript`
- [x] `vp check`
- [x] `vp test` (5 files / 20 tests)
- [x] `vp run deadcode`
- [x] `vp pack` with `.d.ts` output
- [x] `vp build`
- [x] npm tarball smoke on Node.js 24.18.1
