### PR TITLE
refactor!: use native fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 22.x
 
       - name: Extract version tag
         if: startsWith( github.ref, 'refs/tags/v' )

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "prepare": "vp config"
   },
   "dependencies": {
-    "ohmyfetch": "^0.4.18",
     "semver": "^7.3.7",
     "zod": "^3.18.0",
     "zodiarg": "^0.2.1"
@@ -77,7 +76,7 @@
     }
   },
   "engines": {
-    "node": ">= 14.18"
+    "node": ">= 22"
   },
   "packageManager": "pnpm@11.18.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
 
   .:
     dependencies:
-      ohmyfetch:
-        specifier: ^0.4.18
-        version: 0.4.21
       semver:
         specifier: ^7.3.7
         version: 7.8.5
@@ -129,10 +126,6 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1179,9 +1172,6 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  destr@1.2.2:
-    resolution: {integrity: sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==}
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1499,9 +1489,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  node-fetch-native@0.1.8:
-    resolution: {integrity: sha512-ZNaury9r0NxaT2oL65GvdGDy+5PlSaHTovT6JV5tOW07k1TQmgC0olZETa4C9KZg0+6zBr99ctTYa3Utqj9P/Q==}
-
   node@runtime:24.18.1:
     resolution:
       type: variations
@@ -1629,10 +1616,6 @@ packages:
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
-
-  ohmyfetch@0.4.21:
-    resolution: {integrity: sha512-VG7f/JRvqvBOYvL0tHyEIEG7XHWm7OqIfAs6/HqwWwDfjiJ1g0huIpe5sFEmyb+7hpFa1EGNH2aERWR72tlClw==}
-    deprecated: Package renamed to https://github.com/unjs/ofetch
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1865,9 +1848,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@0.8.6:
-    resolution: {integrity: sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==}
-
   unbash@4.0.4:
     resolution: {integrity: sha512-60m9IVGbavD6jholbxt0jVBXZkEB/HsMZq7Tyaghseve2/Sf0zQRAIfWsD34sde+DKP2tBxJS2wP88ZM0D1FhA==}
     engines: {node: '>=14'}
@@ -1880,10 +1860,6 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -2087,8 +2063,6 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
-
-  '@fastify/busboy@2.1.1': {}
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -2767,8 +2741,6 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  destr@1.2.2: {}
-
   detect-libc@2.1.2: {}
 
   dom-accessibility-api@0.5.16: {}
@@ -3058,20 +3030,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  node-fetch-native@0.1.8: {}
-
   node@runtime:24.18.1: {}
 
   object-deep-merge@2.0.1: {}
 
   obug@2.1.4: {}
-
-  ohmyfetch@0.4.21:
-    dependencies:
-      destr: 1.2.2
-      node-fetch-native: 0.1.8
-      ufo: 0.8.6
-      undici: 5.29.0
 
   optionator@0.9.4:
     dependencies:
@@ -3342,8 +3305,6 @@ snapshots:
   typescript@6.0.3:
     optional: true
 
-  ufo@0.8.6: {}
-
   unbash@4.0.4: {}
 
   unconfig-core@7.5.0:
@@ -3360,10 +3321,6 @@ snapshots:
       unconfig-core: 7.5.0
 
   undici-types@7.18.2: {}
-
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
 
   uri-js@4.4.1:
     dependencies:

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -72,6 +72,8 @@ try {
     import: './dist/index.mjs'
   })
   assert.equal(packageJson.bin, './cli.mjs')
+  assert.equal(packageJson.engines.node, '>= 22')
+  assert.equal(packageJson.dependencies.ohmyfetch, undefined)
 
   if (process.platform !== 'win32') {
     const wrapper = await stat(join(packageDirectory, 'cli.mjs'))

--- a/src/__tests__/core/fetcher.test.ts
+++ b/src/__tests__/core/fetcher.test.ts
@@ -1,22 +1,23 @@
 import { vi } from 'vite-plus/test'
-import { $fetch } from 'ohmyfetch'
 import { fetchGithubRelease } from '../../fetcher'
 import release from '../fixtures/release.json'
 
 import type { GitHubRelease, Fetcher, FetcherOptions } from '../../types'
 
-vi.mock('ohmyfetch', async () => {
-  return {
-    $fetch: vi.fn<typeof $fetch>()
-  }
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
 })
 
 describe('fetchGithubRelease', () => {
   test('default', async () => {
     // mocking
-    vi.mocked($fetch).mockImplementationOnce(() => {
-      return Promise.resolve(release)
-    })
+    fetchMock.mockResolvedValueOnce(Response.json(release))
 
     // assertion
     expect(
@@ -25,6 +26,24 @@ describe('fetchGithubRelease', () => {
         token: 'foo'
       } as FetcherOptions)
     ).toEqual(release)
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.github.com/repos/kazupon/gh-changelogen/releases/tags/${release.tag_name}`,
+      {
+        headers: {
+          accept: 'application/vnd.github.v3+json',
+          authorization: 'token foo'
+        },
+        method: 'GET'
+      }
+    )
+  })
+
+  test('default fetcher error', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 404, statusText: 'Not Found' }))
+
+    await expect(
+      fetchGithubRelease(release.tag_name, { github: 'kazupon/gh-changelogen' })
+    ).rejects.toThrow('GitHub API request failed: 404 Not Found')
   })
 
   test('custom fetcher', async () => {

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,14 +1,15 @@
-import { $fetch } from 'ohmyfetch'
-
 import { isFunction } from './utils'
 
 import type { GitHubRelease, Fetcher, FetcherOptions } from './types'
 
 function getHeaders(options: FetcherOptions) {
-  return {
-    accept: 'application/vnd.github.v3+json',
-    authorization: `token ${options.token}`
+  const headers: Record<string, string> = {
+    accept: 'application/vnd.github.v3+json'
   }
+  if (options.token) {
+    headers.authorization = `token ${options.token}`
+  }
+  return headers
 }
 
 async function fetcherDefault(tag: string, options: FetcherOptions = {}): Promise<GitHubRelease> {
@@ -17,7 +18,11 @@ async function fetcherDefault(tag: string, options: FetcherOptions = {}): Promis
   }
 
   const url = `https://api.github.com/repos/${options.github}/releases/tags/${tag}`
-  return $fetch<GitHubRelease>(url, { headers: getHeaders(options), method: 'GET' })
+  const response = await fetch(url, { headers: getHeaders(options), method: 'GET' })
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed: ${response.status} ${response.statusText}`)
+  }
+  return (await response.json()) as GitHubRelease
 }
 
 export async function fetchGithubRelease(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import {
 } from '@kazupon/vp-config'
 import { defineConfig } from 'vite-plus'
 
-const externalDependencies = ['ohmyfetch', 'semver', 'zod', 'zodiarg']
+const externalDependencies = ['semver', 'zod', 'zodiarg']
 
 export default defineConfig({
   staged: {
@@ -23,7 +23,7 @@ export default defineConfig({
     dts: true,
     format: ['esm', 'cjs'],
     platform: 'node',
-    target: 'node14.18',
+    target: 'node22',
     fixedExtension: true,
     outExtensions: ({ format }) => ({
       js: format === 'cjs' ? '.cjs' : '.mjs',


### PR DESCRIPTION
## Summary

- replace `ohmyfetch` with the Node.js native `fetch` API
- preserve JSON parsing and non-2xx error handling in the default GitHub release fetcher
- omit the Authorization header when no token is provided
- remove `ohmyfetch` from dependencies and the Vite external list
- raise `engines.node` and the package build target to Node.js 22
- update tests, package smoke assertions, and the README workflow example

## Breaking change

Node.js 22 or newer is now required. Node.js 14–20 are no longer supported.

The CI consumer matrix remains Node.js 22 and 24.

## Why

The project now develops and releases with Vite+ on Node.js 24, while its supported consumer runtimes already run on Node.js 22/24. Both runtimes provide native `fetch`, so the compatibility dependency is no longer needed.

## Validation

- [x] `vp install --frozen-lockfile`
- [x] `vp check`
- [x] `vp test` on Node.js 24 (5 files / 21 tests)
- [x] `vp test` on Node.js 22.23.2
- [x] `vp run deadcode`
- [x] `vp pack`
- [x] `vp build`
- [x] npm tarball smoke on Node.js 24.18.1
- [x] npm tarball smoke on Node.js 22.23.2
- [x] no remaining `ohmyfetch` references
