### PR TITLE
chore: preserve agent instructions on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lint:fix": "vp lint --fix",
     "knip": "knip",
     "knip:fix": "knip --fix",
-    "prepare": "vp config"
+    "prepare": "vp config --no-agent"
   },
   "dependencies": {
     "gunshi": "^0.37.1",


### PR DESCRIPTION
## Summary

- pass `--no-agent` to the Vite+ `prepare` command
- keep Vite+ Git hook setup enabled while preventing install-time rewrites of `AGENTS.md` and `CLAUDE.md`

## Why

`vp install` runs the package's `prepare` lifecycle script. Plain `vp config` updates existing coding-agent instruction files by default, which overwrote this repository's customized validation guidance. Vite+ officially provides `--no-agent` to skip only that integration.

## Validation

- `vp install` completed and ran `vp config --no-agent`
- verified `AGENTS.md` and `CLAUDE.md` remained unchanged after installation
- `vpr check`
- `vpr test` — 11 files / 105 tests
