### PR TITLE
chore(release): generate changelog before tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Triggers:
-#   - tag push (v*): publish to npm, then update the release notes.
+#   - tag push (v*): publish to npm, then create the GitHub Release.
 #   - workflow_dispatch: retry either job for an existing tag.
 on:
   push:
@@ -77,7 +77,7 @@ jobs:
         run: npm publish --access public --tag latest
 
   release-notes:
-    name: Update release notes
+    name: Create GitHub Release
     needs:
       - npm-publish
     if: >-
@@ -90,28 +90,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write # GitHub Release creation + CHANGELOG push
+      contents: write # GitHub Release creation
 
     steps:
       - name: Checkout codes
-        # zizmor: ignore[artipacked] -- git-auto-commit-action needs persisted credentials to push.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
-          fetch-depth: 0
-
-      - name: Setup Vite Plus
-        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
-        with:
-          node-version: 24
-          cache: true
-          run-install: false
-
-      - name: Install dependencies
-        run: vp install --frozen-lockfile
-
-      - name: Build
-        run: vp pack
+          ref: ${{ env.TAG }}
+          persist-credentials: false
 
       - name: Create GitHub Release
         run: |
@@ -122,15 +108,3 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Sync changelog from GitHub Releases
-        run: ./cli.mjs --repo=kazupon/gh-changelogen --tag="$TAG"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit changelog
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
-        with:
-          branch: main
-          file_pattern: CHANGELOG.md
-          commit_message: 'chore: generate changelog'

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Before releasing:
 - Ensure `HEAD` is already available on the GitHub remote. Generated notes cannot target an
   unpushed commit.
 - Track `CHANGELOG.md` before the release. `git commit --all` does not add untracked files.
-- Keep bumpp's clean-tree check enabled because `all: true` includes every tracked change.
+- Do not carry unrelated tracked changes: `all: true` includes every tracked change.
 - Ensure the future tag does not already exist locally or remotely.
 - Set `GH_TOKEN` or `GITHUB_TOKEN` with `Contents: write` permission.
 
@@ -219,26 +219,30 @@ execFileSync(
 The wrapper passes an argument array without constructing another shell command. A non-zero
 gh-changelogen exit stops bumpp before commit, tag, and push.
 
-## GitHub Actions
+### Releasing gh-changelogen itself
 
-The existing published-mode flow remains supported: create the GitHub Release first, then run
-gh-changelogen without `--generate-notes`.
+This repository uses its local CLI in the same prerelease flow:
 
-```yaml
-- name: Create GitHub Release
-  run: gh release create "$TAG" --generate-notes
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-- name: Generate changelog from the published Release
-  run: npx gh-changelogen --repo=kazupon/gh-changelogen --tag="$TAG"
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```sh
+GH_TOKEN="$(gh auth token)" vp run release
 ```
 
-After adopting the bumpp prerelease flow, the post-release changelog commit can be removed from
-the workflow. GitHub Release creation should still happen only after package publication and its
-smoke test succeed.
+The release script first builds the local CLI. bumpp then updates `package.json` and invokes that
+CLI with the selected future version, `--generate-notes`, and `--target=HEAD`. Its `all: true`
+configuration puts the version and `CHANGELOG.md` changes in the same release commit before
+creating and pushing the tag.
+
+If changelog generation fails, bumpp stops before commit, tag, and push. Start from a clean main
+branch whose `HEAD` is already available on GitHub.
+
+## GitHub Actions
+
+For this repository, the tag-push workflow publishes the package first and creates the GitHub
+Release only after npm publication succeeds. It does not generate or commit `CHANGELOG.md`;
+that file is already part of the tagged release commit produced by `vp run release`.
+
+The workflow's `release-notes` dispatch option remains available to retry GitHub Release creation
+for an existing tag without republishing the package.
 
 ## Failure and recovery
 

--- a/bump.config.ts
+++ b/bump.config.ts
@@ -1,0 +1,29 @@
+/// <reference types="node" />
+
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'bumpp'
+
+const cli = fileURLToPath(new URL('./cli.mjs', import.meta.url))
+
+export default defineConfig({
+  all: true,
+  commit: 'release: v{version}',
+  execute: operation => {
+    execFileSync(
+      process.execPath,
+      [
+        cli,
+        '--repo=kazupon/gh-changelogen',
+        `--tag=v${operation.state.newVersion}`,
+        '--generate-notes',
+        '--target=HEAD',
+        '--output=CHANGELOG.md'
+      ],
+      { stdio: 'inherit' }
+    )
+  },
+  push: true,
+  tag: true
+})

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prepack": "vp pack",
     "typecheck": "vp check --no-fmt --no-lint",
     "test": "vp test",
-    "release": "bumpp --commit \"release: v%s\" --push --tag",
+    "release": "vp pack && bumpp",
     "check": "vp check && vp run knip",
     "fix": "vp check --fix && vp run knip:fix",
     "format": "vp fmt --check",

--- a/src/__tests__/core/bump-config.test.ts
+++ b/src/__tests__/core/bump-config.test.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { vi } from 'vite-plus/test'
+
+import packageJson from '../../../package.json' with { type: 'json' }
+import config from '../../../bump.config'
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn<typeof execFileSync>()
+}))
+
+beforeEach(() => {
+  vi.mocked(execFileSync).mockReset()
+})
+
+test('builds the local CLI before running bumpp', () => {
+  expect(packageJson.scripts.release).toBe('vp pack && bumpp')
+})
+
+test('generates the changelog for the version selected by bumpp', async () => {
+  expect(config).toMatchObject({
+    all: true,
+    commit: 'release: v{version}',
+    push: true,
+    tag: true
+  })
+
+  const execute = config.execute
+  expect(execute).toBeTypeOf('function')
+  if (typeof execute !== 'function') {
+    return
+  }
+
+  await execute({
+    state: {
+      newVersion: '2.1.0'
+    }
+  } as Parameters<typeof execute>[0])
+
+  expect(execFileSync).toHaveBeenCalledWith(
+    process.execPath,
+    [
+      fileURLToPath(new URL('../../../cli.mjs', import.meta.url)),
+      '--repo=kazupon/gh-changelogen',
+      '--tag=v2.1.0',
+      '--generate-notes',
+      '--target=HEAD',
+      '--output=CHANGELOG.md'
+    ],
+    { stdio: 'inherit' }
+  )
+})

--- a/src/__tests__/core/release-workflow.test.ts
+++ b/src/__tests__/core/release-workflow.test.ts
@@ -1,0 +1,22 @@
+import { readFile } from 'node:fs/promises'
+
+let workflow: string
+
+beforeAll(async () => {
+  workflow = await readFile(
+    new URL('../../../.github/workflows/release.yml', import.meta.url),
+    'utf8'
+  )
+})
+
+test('creates the GitHub Release from the pushed tag', () => {
+  expect(workflow).toContain('name: Create GitHub Release')
+  expect(workflow).toContain('ref: ${{ env.TAG }}')
+  expect(workflow).toContain('gh release create "$TAG" --generate-notes')
+})
+
+test('does not update the changelog after publication', () => {
+  expect(workflow).not.toContain('Sync changelog from GitHub Releases')
+  expect(workflow).not.toContain('git-auto-commit-action')
+  expect(workflow).not.toContain('file_pattern: CHANGELOG.md')
+})


### PR DESCRIPTION
## Summary

- add a bumpp function hook that runs the local v2 CLI with `--generate-notes` for the selected future version
- include `CHANGELOG.md` in the same release commit before the tag is created and pushed
- simplify `release.yml` so it publishes npm and creates the GitHub Release without mutating `main` afterward
- document the repository release flow and add regression coverage for the bumpp config and workflow

## Validation

- `vpr check`
- `vpr test` (109 tests)
- `vp pack`
- `actionlint .github/workflows/release.yml`
- `npm pack --dry-run --json`
- pre-commit `vp check --fix`
